### PR TITLE
Stac Browser - V3 Catalog and Items projection

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commonmark": "^0.29.3",
     "core-js": "^3.6.5",
     "leaflet": "~1.7.1",
+    "proj4-fully-loaded": "^0.0.4",
     "remove-markdown": "^0.3.0",
     "stac-layer": "^0.10.1",
     "urijs": "^1.19.11",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,7 @@ import axios from "axios";
 import Utils from '../utils'
 import STAC from '../stac';
 import bs58 from 'bs58';
-import { Loading, stacRequest } from './utils';
+import { Loading, stacRequest, convertCoordinatesToEpsg4326 } from './utils';
 import URI from "urijs";
 
 Vue.use(Vuex);
@@ -542,7 +542,7 @@ function getStore(config) {
             if (!Utils.isObject(response.data)) {
               throw new Error('The response is not a valid STAC JSON');
             }
-            data = new STAC(response.data, url, path);
+            data = new STAC(convertCoordinatesToEpsg4326(response.data), url, path);
             cx.commit('loaded', {url, data});
 
             if (!cx.getters.root) {

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import Utils from "../utils";
+import proj4 from "proj4-fully-loaded";
 
 export class Loading {
   
@@ -33,4 +34,57 @@ export async function stacRequest(cx, link) {
     opts = link;
   }
   return await axios(opts);
+}
+
+function getGeoCoordinatesConverted(array, stacEpsg) {
+  const geoCoordinatesConverted = array.map((elem) => {
+    if (typeof elem[0] === 'number') {
+      return proj4(`${stacEpsg}`, "EPSG:4326", [elem[0], elem[1]]);
+    } else {
+      return getGeoCoordinatesConverted(elem, stacEpsg);
+    }
+  })
+  return geoCoordinatesConverted;
+}
+
+function getBboxCoordinatesConverted(array, stacEpsg) {
+  let bboxCoordinatesConverted = [];
+  const bboxCoordinatesReProjection = (elem) => {
+    return [...proj4(`${stacEpsg}`, "EPSG:4326", [elem[0], elem[1]]), ...proj4(`${stacEpsg}`, "EPSG:4326", [elem[2], elem[3]])];
+  }
+  if (typeof array[0] === 'number') {
+    bboxCoordinatesConverted.push(...bboxCoordinatesReProjection(array));
+  } else {
+    bboxCoordinatesConverted.push(...array.map((elem) => {
+      return bboxCoordinatesReProjection(elem);
+    })
+    )
+  }
+  return bboxCoordinatesConverted;
+}
+
+export const convertCoordinatesToEpsg4326 = (stacObj) => {
+  if (stacObj && !!stacObj['crs']) {
+    const stacEpsg = stacObj.crs.init.toUpperCase();
+
+    if (!!stacObj['geometry'] && stacObj['type'] === 'Feature' && stacEpsg !== 'EPSG:4326') {
+      const geoCoordinates = stacObj.geometry.coordinates;
+      const bboxCoordinates = stacObj.bbox;
+      const geoCoordinatesConverted = getGeoCoordinatesConverted(geoCoordinates, stacEpsg);
+      const bboxCoordinatesConverted = getBboxCoordinatesConverted(bboxCoordinates, stacEpsg);
+
+      stacObj.geometry.coordinates = geoCoordinatesConverted;
+      stacObj.bbox = bboxCoordinatesConverted;
+
+      delete stacObj.properties.crs;
+
+    } else if (!!stacObj['extent'] && stacObj['type'] === 'Collection' && stacEpsg !== 'EPSG:4326') {
+      const bboxCoordinates = stacObj.extent.spatial.bbox;
+      const bboxCoordinatesConverted = getBboxCoordinatesConverted(bboxCoordinates, stacEpsg);
+      stacObj.extent.spatial.bbox = bboxCoordinatesConverted;
+
+    }
+    delete stacObj.crs;
+  }
+  return stacObj;
 }


### PR DESCRIPTION
**Related Asana Issue:**
- [STAC Browser + Proj4](https://app.asana.com/0/1200802773613549/1202223349262720/f)

**Description:**
- Modify the STAC Browser to be able to use custom projections by convertion the `epsg 32632` to `epsg 4326` projections.

**Changes details:**
- This projection conversion is implemented in `stac_browser v3 (Branch: v3)` (tesselo fork)

**PR v2:**
- In order to test the conversion before GeoJSON implementation new structure you should add in `utils.js` line 40 , before the initial if statement, the following code: 

`const geoOrExt = !!stacObj['geometry'] || !!stacObj['extent']`
`stacObj = geoOrExt && !stacObj['type'] ? {...stacObj, "type": "Collection"} : stacObj`
`stacObj = geoOrExt && !stacObj['crs'] ? {...stacObj, "crs": {"init": "epsg:32632"}} : stacObj`

- This will add the above and future new properties in the GeoJSON.